### PR TITLE
Add minimal project management API

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,0 +1,16 @@
+module.exports = {
+  env: {
+    node: true,
+    es2020: true,
+  },
+  parser: '@typescript-eslint/parser',
+  plugins: ['@typescript-eslint', 'prettier'],
+  extends: [
+    'eslint:recommended',
+    'plugin:@typescript-eslint/recommended',
+    'plugin:prettier/recommended',
+  ],
+  rules: {
+    'prettier/prettier': 'error',
+  },
+};

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+node_modules
+.env
+build
+dist

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,5 @@
+{
+  "singleQuote": true,
+  "trailingComma": "all",
+  "semi": true
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,30 @@
+{
+  "name": "project-manager",
+  "version": "1.0.0",
+  "main": "dist/index.js",
+  "scripts": {
+    "build": "tsc",
+    "start": "node dist/index.js",
+    "dev": "ts-node src/index.ts",
+    "lint": "eslint --ext .ts src",
+    "format": "prettier --write ."
+  },
+  "dependencies": {
+    "bcryptjs": "^2.4.3",
+    "express": "^4.18.2",
+    "jsonwebtoken": "^9.0.0",
+    "uuid": "^9.0.0"
+  },
+  "devDependencies": {
+    "@types/bcryptjs": "^2.4.2",
+    "@types/express": "^4.17.17",
+    "@types/jsonwebtoken": "^9.0.1",
+    "eslint": "^8.47.0",
+    "eslint-config-prettier": "^8.8.0",
+    "eslint-plugin-prettier": "^4.2.1",
+    "prettier": "^2.8.8",
+    "ts-node": "^10.9.1",
+    "typescript": "^5.2.2",
+    "@types/uuid": "^9.0.1"
+  }
+}

--- a/src/controllers/calendarController.ts
+++ b/src/controllers/calendarController.ts
@@ -1,0 +1,11 @@
+import type { Response } from 'express';
+import { tasks } from '../store';
+import type { AuthRequest } from '../middleware/auth';
+
+export const getCalendar = (req: AuthRequest, res: Response): void => {
+  const { projectId } = req.params;
+  const events = tasks
+    .filter((t) => t.projectId === projectId && t.dueDate)
+    .map((t) => ({ title: t.title, date: t.dueDate }));
+  res.json(events);
+};

--- a/src/controllers/dashboardController.ts
+++ b/src/controllers/dashboardController.ts
@@ -1,0 +1,19 @@
+import type { Response } from 'express';
+import { projects, tasks } from '../store';
+import type { AuthRequest } from '../middleware/auth';
+
+export const getDashboard = (req: AuthRequest, res: Response): void => {
+  const userId = req.user!.id;
+  const userProjects = projects.filter((p) =>
+    p.members.some((m) => m.userId === userId),
+  );
+  const overview = userProjects.map((p) => {
+    const projectTasks = tasks.filter((t) => t.projectId === p.id);
+    return {
+      project: p.name,
+      totalTasks: projectTasks.length,
+      done: projectTasks.filter((t) => t.status === 'done').length,
+    };
+  });
+  res.json(overview);
+};

--- a/src/controllers/logController.ts
+++ b/src/controllers/logController.ts
@@ -1,0 +1,9 @@
+import type { Response } from 'express';
+import { logs } from '../store';
+import type { AuthRequest } from '../middleware/auth';
+
+export const listLogs = (req: AuthRequest, res: Response): void => {
+  const { projectId } = req.params;
+  const projectLogs = logs.filter((l) => l.projectId === projectId);
+  res.json(projectLogs);
+};

--- a/src/controllers/projectController.ts
+++ b/src/controllers/projectController.ts
@@ -1,0 +1,63 @@
+import { v4 as uuid } from 'uuid';
+import type { Request, Response } from 'express';
+import { projects, addLog } from '../store';
+import type { AuthRequest } from '../middleware/auth';
+import type { Project } from '../types/project';
+
+export const listProjects = (req: AuthRequest, res: Response): void => {
+  const userId = req.user?.id;
+  const visible = projects.filter((p) =>
+    p.members.some((m) => m.userId === userId),
+  );
+  res.json(visible);
+};
+
+export const createProject = (req: AuthRequest, res: Response): void => {
+  const { name } = req.body as { name: string };
+  const project: Project = {
+    id: uuid(),
+    name,
+    members: [{ userId: req.user!.id, role: 'Admin' }],
+  };
+  projects.push(project);
+  addLog(project.id, `Project ${name} created`);
+  res.json(project);
+};
+
+export const updateProject = (req: AuthRequest, res: Response): void => {
+  const { id } = req.params;
+  const { name } = req.body as { name: string };
+  const project = projects.find((p) => p.id === id);
+  if (!project) {
+    res.status(404).json({ message: 'Not found' });
+    return;
+  }
+  project.name = name;
+  addLog(id, `Project updated`);
+  res.json(project);
+};
+
+export const deleteProject = (req: AuthRequest, res: Response): void => {
+  const { id } = req.params;
+  const index = projects.findIndex((p) => p.id === id);
+  if (index === -1) {
+    res.status(404).json({ message: 'Not found' });
+    return;
+  }
+  projects.splice(index, 1);
+  addLog(id, `Project deleted`);
+  res.status(204).send();
+};
+
+export const inviteMember = (req: AuthRequest, res: Response): void => {
+  const { id } = req.params;
+  const { userId, role } = req.body as { userId: string; role: 'Admin' | 'Member' };
+  const project = projects.find((p) => p.id === id);
+  if (!project) {
+    res.status(404).json({ message: 'Not found' });
+    return;
+  }
+  project.members.push({ userId, role });
+  addLog(id, `User ${userId} invited`);
+  res.json(project);
+};

--- a/src/controllers/taskController.ts
+++ b/src/controllers/taskController.ts
@@ -1,0 +1,44 @@
+import { v4 as uuid } from 'uuid';
+import type { Response } from 'express';
+import { tasks, addLog } from '../store';
+import type { AuthRequest } from '../middleware/auth';
+import type { Task, TaskStatus } from '../types/task';
+
+export const listTasks = (req: AuthRequest, res: Response): void => {
+  const { projectId } = req.params;
+  const projectTasks = tasks.filter((t) => t.projectId === projectId);
+  res.json(projectTasks);
+};
+
+export const createTask = (req: AuthRequest, res: Response): void => {
+  const { projectId } = req.params;
+  const { title, dueDate, priority } = req.body as {
+    title: string;
+    dueDate?: string;
+    priority?: number;
+  };
+  const task: Task = {
+    id: uuid(),
+    projectId,
+    title,
+    status: 'todo',
+    dueDate,
+    priority,
+  };
+  tasks.push(task);
+  addLog(projectId, `Task ${title} created`);
+  res.json(task);
+};
+
+export const updateTask = (req: AuthRequest, res: Response): void => {
+  const { taskId } = req.params;
+  const { status } = req.body as { status: TaskStatus };
+  const task = tasks.find((t) => t.id === taskId);
+  if (!task) {
+    res.status(404).json({ message: 'Not found' });
+    return;
+  }
+  task.status = status;
+  addLog(task.projectId, `Task ${task.title} updated to ${status}`);
+  res.json(task);
+};

--- a/src/controllers/userController.ts
+++ b/src/controllers/userController.ts
@@ -1,0 +1,41 @@
+import { v4 as uuid } from 'uuid';
+import bcrypt from 'bcryptjs';
+import { users } from '../store';
+import type { Request, Response } from 'express';
+import type { Role, User } from '../types/user';
+import { signToken } from '../middleware/auth';
+
+export const signup = async (req: Request, res: Response): Promise<void> => {
+  const { username, password, role } = req.body as {
+    username: string;
+    password: string;
+    role: Role;
+  };
+  const existing = users.find((u) => u.username === username);
+  if (existing) {
+    res.status(409).json({ message: 'User exists' });
+    return;
+  }
+  const passwordHash = await bcrypt.hash(password, 10);
+  const user: User = { id: uuid(), username, passwordHash, role };
+  users.push(user);
+  res.json({ token: signToken(user) });
+};
+
+export const login = async (req: Request, res: Response): Promise<void> => {
+  const { username, password } = req.body as {
+    username: string;
+    password: string;
+  };
+  const user = users.find((u) => u.username === username);
+  if (!user) {
+    res.status(401).json({ message: 'Invalid credentials' });
+    return;
+  }
+  const match = await bcrypt.compare(password, user.passwordHash);
+  if (!match) {
+    res.status(401).json({ message: 'Invalid credentials' });
+    return;
+  }
+  res.json({ token: signToken(user) });
+};

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,0 +1,49 @@
+import express from 'express';
+import {
+  signup,
+  login,
+} from './controllers/userController';
+import {
+  listProjects,
+  createProject,
+  updateProject,
+  deleteProject,
+  inviteMember,
+} from './controllers/projectController';
+import {
+  listTasks,
+  createTask,
+  updateTask,
+} from './controllers/taskController';
+import { getCalendar } from './controllers/calendarController';
+import { listLogs } from './controllers/logController';
+import { getDashboard } from './controllers/dashboardController';
+import { authenticate } from './middleware/auth';
+
+const app = express();
+app.use(express.json());
+
+app.post('/api/signup', signup);
+app.post('/api/login', login);
+
+app.use(authenticate);
+
+app.get('/api/projects', listProjects);
+app.post('/api/projects', createProject);
+app.put('/api/projects/:id', updateProject);
+app.delete('/api/projects/:id', deleteProject);
+app.post('/api/projects/:id/invite', inviteMember);
+
+app.get('/api/projects/:projectId/tasks', listTasks);
+app.post('/api/projects/:projectId/tasks', createTask);
+app.put('/api/tasks/:taskId', updateTask);
+
+app.get('/api/calendar/:projectId', getCalendar);
+app.get('/api/logs/:projectId', listLogs);
+app.get('/api/dashboard', getDashboard);
+
+const PORT = process.env.PORT || 3000;
+app.listen(PORT, () => {
+  // Server startup logged for debugging
+  console.log(`Server running on port ${PORT}`);
+});

--- a/src/middleware/auth.ts
+++ b/src/middleware/auth.ts
@@ -1,0 +1,31 @@
+import { Request, Response, NextFunction } from 'express';
+import jwt from 'jsonwebtoken';
+import type { User } from '../types/user';
+
+const secret = 'secret-key';
+
+export interface AuthRequest extends Request {
+  user?: User;
+}
+
+export const authenticate = (
+  req: AuthRequest,
+  res: Response,
+  next: NextFunction,
+): void => {
+  const token = req.headers.authorization?.split(' ')[1];
+  if (!token) {
+    res.status(401).json({ message: 'Unauthorized' });
+    return;
+  }
+  try {
+    const decoded = jwt.verify(token, secret) as User;
+    req.user = decoded;
+    next();
+  } catch {
+    res.status(401).json({ message: 'Invalid token' });
+  }
+};
+
+export const signToken = (user: User): string =>
+  jwt.sign(user, secret, { expiresIn: '1h' });

--- a/src/store.ts
+++ b/src/store.ts
@@ -1,0 +1,14 @@
+import { v4 as uuid } from 'uuid';
+import type { ActivityLog } from './types/log';
+import type { Project } from './types/project';
+import type { Task } from './types/task';
+import type { User } from './types/user';
+
+export const users: User[] = [];
+export const projects: Project[] = [];
+export const tasks: Task[] = [];
+export const logs: ActivityLog[] = [];
+
+export const addLog = (projectId: string, message: string): void => {
+  logs.push({ id: uuid(), projectId, message, timestamp: Date.now() });
+};

--- a/src/types/log.ts
+++ b/src/types/log.ts
@@ -1,0 +1,6 @@
+export interface ActivityLog {
+  id: string;
+  projectId: string;
+  message: string;
+  timestamp: number;
+}

--- a/src/types/project.ts
+++ b/src/types/project.ts
@@ -1,0 +1,12 @@
+import type { Role } from './user';
+
+export interface ProjectMember {
+  userId: string;
+  role: Role;
+}
+
+export interface Project {
+  id: string;
+  name: string;
+  members: ProjectMember[];
+}

--- a/src/types/task.ts
+++ b/src/types/task.ts
@@ -1,0 +1,10 @@
+export type TaskStatus = 'todo' | 'in_progress' | 'done';
+
+export interface Task {
+  id: string;
+  projectId: string;
+  title: string;
+  status: TaskStatus;
+  dueDate?: string;
+  priority?: number;
+}

--- a/src/types/user.ts
+++ b/src/types/user.ts
@@ -1,0 +1,8 @@
+export type Role = 'Admin' | 'Member';
+
+export interface User {
+  id: string;
+  username: string;
+  passwordHash: string;
+  role: Role;
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "commonjs",
+    "outDir": "dist",
+    "rootDir": "src",
+    "strict": true,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "skipLibCheck": true
+  },
+  "include": ["src/**/*"]
+}


### PR DESCRIPTION
## Summary
- configure TypeScript, ESLint and Prettier
- implement JWT-based user signup/login
- add project, task, calendar, log and dashboard controllers
- centralize in-memory data store
- expose REST API endpoints

## Testing
- `npm run lint` *(fails: ESLint couldn't find configuration without dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6847db001de483339462f231fe7af774