### PR TITLE
Add project registration modal

### DIFF
--- a/client/src/components/AddProjectModal.tsx
+++ b/client/src/components/AddProjectModal.tsx
@@ -1,0 +1,107 @@
+import { useState } from 'react';
+import { Modal } from './ui/Modal';
+import { Button } from './ui/Button';
+import type { NewProject } from '../types';
+
+interface AddProjectModalProps {
+  onAdd: (project: NewProject) => void;
+  onClose: () => void;
+}
+
+export function AddProjectModal({
+  onAdd,
+  onClose,
+}: AddProjectModalProps): JSX.Element {
+  const [type, setType] = useState<'신규' | '추가'>('신규');
+  const [name, setName] = useState('');
+  const [period, setPeriod] = useState('');
+  const [description, setDescription] = useState('');
+  const [os, setOs] = useState('');
+  const [totalMemory, setTotalMemory] = useState<number>(0);
+  const [availableMemory, setAvailableMemory] = useState<number>(0);
+  const [requestDetail, setRequestDetail] = useState('');
+
+  function handleSubmit(e: React.FormEvent): void {
+    e.preventDefault();
+    onAdd({
+      type,
+      name,
+      period,
+      description,
+      os,
+      totalMemory,
+      availableMemory,
+      requestDetail,
+    });
+    onClose();
+  }
+
+  return (
+    <Modal onClose={onClose}>
+      <form onSubmit={handleSubmit} className="space-y-2">
+        <select
+          className="w-full rounded border p-2"
+          value={type}
+          onChange={(e) => setType(e.target.value as '신규' | '추가')}
+        >
+          <option value="신규">신규</option>
+          <option value="추가">추가</option>
+        </select>
+        <input
+          className="w-full rounded border p-2"
+          placeholder="프로젝트 명"
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+        />
+        <input
+          className="w-full rounded border p-2"
+          placeholder="기간"
+          value={period}
+          onChange={(e) => setPeriod(e.target.value)}
+        />
+        <textarea
+          className="w-full rounded border p-2"
+          placeholder="내용"
+          value={description}
+          onChange={(e) => setDescription(e.target.value)}
+        />
+        <input
+          className="w-full rounded border p-2"
+          placeholder="OS 종류"
+          value={os}
+          onChange={(e) => setOs(e.target.value)}
+        />
+        <input
+          className="w-full rounded border p-2"
+          placeholder="총 메모리"
+          type="number"
+          value={totalMemory}
+          onChange={(e) => setTotalMemory(Number(e.target.value))}
+        />
+        <input
+          className="w-full rounded border p-2"
+          placeholder="가용 메모리"
+          type="number"
+          value={availableMemory}
+          onChange={(e) => setAvailableMemory(Number(e.target.value))}
+        />
+        <textarea
+          className="w-full rounded border p-2"
+          placeholder="프로젝트 요청 사항"
+          value={requestDetail}
+          onChange={(e) => setRequestDetail(e.target.value)}
+        />
+        <div className="flex justify-end gap-2 pt-2">
+          <Button type="submit">등록</Button>
+          <Button
+            type="button"
+            className="bg-gray-300 text-black"
+            onClick={onClose}
+          >
+            취소
+          </Button>
+        </div>
+      </form>
+    </Modal>
+  );
+}

--- a/client/src/components/ui/Modal.tsx
+++ b/client/src/components/ui/Modal.tsx
@@ -1,0 +1,23 @@
+import { ReactNode } from 'react';
+
+interface ModalProps {
+  children: ReactNode;
+  onClose: () => void;
+}
+
+export function Modal({ children, onClose }: ModalProps): JSX.Element {
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50">
+      <div className="rounded-lg bg-white p-6 shadow-lg">
+        <button
+          type="button"
+          onClick={onClose}
+          className="absolute right-2 top-2 text-gray-500 hover:text-gray-700"
+        >
+          ×
+        </button>
+        {children}
+      </div>
+    </div>
+  );
+}

--- a/client/src/context/DataContext.tsx
+++ b/client/src/context/DataContext.tsx
@@ -1,12 +1,12 @@
 import { createContext, useContext, useEffect, useState } from 'react';
 import type { ReactNode } from 'react';
-import type { Project, Task } from '../types';
+import type { NewProject, Project, Task } from '../types';
 import { generateId } from '../utils/id';
 
 interface DataContextValue {
   projects: Project[];
   tasks: Task[];
-  addProject: (name: string) => void;
+  addProject: (project: NewProject) => void;
   deleteProject: (id: string) => void;
   addTask: (projectId: string, title: string) => void;
   updateTaskStatus: (taskId: string, status: Task['status']) => void;
@@ -37,8 +37,8 @@ export function DataProvider({
     localStorage.setItem('pm-tasks', JSON.stringify(tasks));
   }, [tasks]);
 
-  function addProject(name: string): void {
-    const project: Project = { id: generateId(), name };
+  function addProject(projectInput: NewProject): void {
+    const project: Project = { id: generateId(), ...projectInput };
     setProjects((prev) => [...prev, project]);
   }
 

--- a/client/src/pages/DashboardPage.tsx
+++ b/client/src/pages/DashboardPage.tsx
@@ -4,32 +4,24 @@ import { useData } from '../context/DataContext';
 import { Button } from '../components/ui/Button';
 import { Card } from '../components/ui/Card';
 import Layout from '../components/Layout';
+import { AddProjectModal } from '../components/AddProjectModal';
 
 function DashboardPage(): JSX.Element {
   const { projects, tasks, addProject } = useData();
-  const [name, setName] = useState<string>('');
-
-  function handleAdd(e: React.FormEvent): void {
-    e.preventDefault();
-    if (!name) return;
-    addProject(name);
-    setName('');
-  }
+  const [showModal, setShowModal] = useState(false);
 
   return (
     <Layout>
       <h1 className="mb-4 text-xl font-bold">Dashboard</h1>
-      <form onSubmit={handleAdd} className="mb-4 flex gap-2">
-        <input
-          value={name}
-          onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
-            setName(e.target.value)
-          }
-          className="flex-1 rounded border p-2"
-          placeholder="New project"
+      <Button className="mb-4" onClick={() => setShowModal(true)}>
+        프로젝트 등록
+      </Button>
+      {showModal && (
+        <AddProjectModal
+          onAdd={addProject}
+          onClose={() => setShowModal(false)}
         />
-        <Button type="submit">Add</Button>
-      </form>
+      )}
       <div className="space-y-2">
         {projects.map((p) => {
           const count = tasks.filter((t) => t.projectId === p.id).length;

--- a/client/src/types/index.ts
+++ b/client/src/types/index.ts
@@ -6,8 +6,17 @@ export interface User {
 
 export interface Project {
   id: string;
+  type: '신규' | '추가';
   name: string;
+  period: string;
+  description: string;
+  os: string;
+  totalMemory: number;
+  availableMemory: number;
+  requestDetail: string;
 }
+
+export type NewProject = Omit<Project, 'id'>;
 
 export interface Task {
   id: string;

--- a/client/src/utils/api.ts
+++ b/client/src/utils/api.ts
@@ -14,5 +14,5 @@ export async function api<T>(
   if (!res.ok) {
     throw new Error(res.statusText);
   }
-  return (res.json() as unknown) as T;
+  return res.json() as unknown as T;
 }


### PR DESCRIPTION
## Summary
- add modal UI component
- create `AddProjectModal` for registering projects with additional fields
- extend project types and update context
- replace dashboard form with modal-driven registration

## Testing
- `npm run lint` *(fails: ESLint couldn't find config)*

------
https://chatgpt.com/codex/tasks/task_e_684907606864833393eeb1bded729caa