### PR TITLE
Add calendar dates to project details

### DIFF
--- a/client/src/components/AddProjectModal.tsx
+++ b/client/src/components/AddProjectModal.tsx
@@ -14,7 +14,8 @@ export function AddProjectModal({
 }: AddProjectModalProps): JSX.Element {
   const [type, setType] = useState<'신규' | '추가'>('신규');
   const [name, setName] = useState('');
-  const [period, setPeriod] = useState('');
+  const [startDate, setStartDate] = useState('');
+  const [endDate, setEndDate] = useState('');
   const [description, setDescription] = useState('');
   const [os, setOs] = useState('');
   const [totalMemory, setTotalMemory] = useState<number>(0);
@@ -26,7 +27,8 @@ export function AddProjectModal({
     onAdd({
       type,
       name,
-      period,
+      startDate,
+      endDate,
       description,
       os,
       totalMemory,
@@ -53,12 +55,20 @@ export function AddProjectModal({
           value={name}
           onChange={(e) => setName(e.target.value)}
         />
-        <input
-          className="w-full rounded border p-2"
-          placeholder="기간"
-          value={period}
-          onChange={(e) => setPeriod(e.target.value)}
-        />
+        <div className="flex gap-2">
+          <input
+            className="w-full rounded border p-2"
+            type="date"
+            value={startDate}
+            onChange={(e) => setStartDate(e.target.value)}
+          />
+          <input
+            className="w-full rounded border p-2"
+            type="date"
+            value={endDate}
+            onChange={(e) => setEndDate(e.target.value)}
+          />
+        </div>
         <textarea
           className="w-full rounded border p-2"
           placeholder="내용"

--- a/client/src/pages/ProjectPage.tsx
+++ b/client/src/pages/ProjectPage.tsx
@@ -31,6 +31,29 @@ function ProjectPage(): JSX.Element {
   return (
     <Layout>
       <h1 className="mb-4 text-xl font-bold">{project.name}</h1>
+      <Card className="mb-4 space-y-1 text-sm">
+        <div>
+          <strong>유형:</strong> {project.type}
+        </div>
+        <div>
+          <strong>기간:</strong> {project.startDate} ~ {project.endDate}
+        </div>
+        <div>
+          <strong>내용:</strong> {project.description}
+        </div>
+        <div>
+          <strong>OS:</strong> {project.os}
+        </div>
+        <div>
+          <strong>총 메모리:</strong> {project.totalMemory}
+        </div>
+        <div>
+          <strong>가용 메모리:</strong> {project.availableMemory}
+        </div>
+        <div>
+          <strong>요청 사항:</strong> {project.requestDetail}
+        </div>
+      </Card>
       <form onSubmit={handleAdd} className="mb-4 flex gap-2">
         <input
           value={title}

--- a/client/src/types/index.ts
+++ b/client/src/types/index.ts
@@ -8,7 +8,8 @@ export interface Project {
   id: string;
   type: '신규' | '추가';
   name: string;
-  period: string;
+  startDate: string;
+  endDate: string;
   description: string;
   os: string;
   totalMemory: number;


### PR DESCRIPTION
## Summary
- store project start and end dates
- capture start and end dates when creating a project
- display full project info on project page

## Testing
- `npm run format`
- `npm run lint` *(fails: ESLint couldn't find a config)*

------
https://chatgpt.com/codex/tasks/task_e_6849097f7e308333a3bb1de6034768ec